### PR TITLE
Enhance accessibility and mobile navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,13 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Glouphi provides actionable data analytics and visualizations for enterprise companies">
     <title>Glouphi - Data Analytics Agency</title>
+    <link rel="icon" href="data:image/svg+xml,&lt;svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'&gt;&lt;rect x='2' y='10' width='3' height='4' fill='%231976d2'/&gt;&lt;rect x='7' y='6' width='3' height='8' fill='%234fc3f7'/&gt;&lt;rect x='12' y='2' width='3' height='12' fill='%231976d2'/&gt;&lt;/svg&gt;">
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <header>
         <nav class="container">
             <div class="brand">Glouphi</div>
+            <button class="menu-toggle" aria-label="Toggle navigation">&#9776;</button>
             <ul class="nav-links">
                 <li><a href="#home">Home</a></li>
                 <li><a href="#about">About</a></li>
@@ -19,6 +22,7 @@
             </ul>
         </nav>
     </header>
+    <main>
     <section class="hero" id="home">
         <div class="container">
             <h1>Transforming Data into Strategic Decisions</h1>
@@ -62,7 +66,7 @@
                 <div class="client-logo">
                     <span class="client-icon">
                         <!-- Icono DataSphere: círculo con puntos -->
-                        <svg width="32" height="32" viewBox="0 0 32 32" fill="none">
+                        <svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-label="DataSphere logo">
                             <circle cx="16" cy="16" r="14" stroke="#1976d2" stroke-width="3"/>
                             <circle cx="16" cy="10" r="2" fill="#1976d2"/>
                             <circle cx="22" cy="16" r="2" fill="#1976d2"/>
@@ -75,7 +79,7 @@
                 <div class="client-logo">
                     <span class="client-icon">
                         <!-- Icono BluePeak: montaña -->
-                        <svg width="32" height="32" viewBox="0 0 32 32" fill="none">
+                        <svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-label="BluePeak logo">
                             <polygon points="4,28 16,8 28,28" fill="#4fc3f7"/>
                             <polygon points="12,20 16,14 20,20" fill="#1976d2"/>
                         </svg>
@@ -85,7 +89,7 @@
                 <div class="client-logo">
                     <span class="client-icon">
                         <!-- Icono Quantix: gráfico de barras -->
-                        <svg width="32" height="32" viewBox="0 0 32 32" fill="none">
+                        <svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-label="Quantix logo">
                             <rect x="6" y="18" width="4" height="8" fill="#1976d2"/>
                             <rect x="14" y="12" width="4" height="14" fill="#4fc3f7"/>
                             <rect x="22" y="22" width="4" height="4" fill="#1976d2"/>
@@ -96,7 +100,7 @@
                 <div class="client-logo">
                     <span class="client-icon">
                         <!-- Icono NexaCorp: edificio -->
-                        <svg width="32" height="32" viewBox="0 0 32 32" fill="none">
+                        <svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-label="NexaCorp logo">
                             <rect x="8" y="14" width="16" height="12" fill="#4fc3f7"/>
                             <rect x="12" y="18" width="2" height="4" fill="#1976d2"/>
                             <rect x="18" y="18" width="2" height="4" fill="#1976d2"/>
@@ -119,10 +123,18 @@
             <a href="#" class="cta-btn">Contact Us</a>
         </div>
     </section>
+    </main>
     <footer>
         <div class="container">
             <p>&copy; 2024 Glouphi. All rights reserved.</p>
         </div>
     </footer>
+    <script>
+        const toggle = document.querySelector('.menu-toggle');
+        const nav = document.querySelector('nav');
+        toggle.addEventListener('click', () => {
+            nav.classList.toggle('nav-open');
+        });
+    </script>
 </body>
-</html> 
+</html>

--- a/styles.css
+++ b/styles.css
@@ -23,6 +23,15 @@ nav {
     align-items: center;
 }
 
+.menu-toggle {
+    display: none;
+    background: none;
+    border: none;
+    color: #b0c4de;
+    font-size: 1.8rem;
+    cursor: pointer;
+}
+
 .brand {
     font-size: 2rem;
     font-weight: bold;
@@ -107,6 +116,11 @@ nav {
     border-radius: 10px;
     box-shadow: 0 1px 6px rgba(30, 60, 90, 0.05);
     text-align: center;
+    transition: transform 0.2s ease-in-out;
+}
+
+.service-item:hover {
+    transform: scale(1.05);
 }
 
 .service-item h3 {
@@ -130,6 +144,11 @@ nav {
     font-weight: bold;
     font-size: 1.1rem;
     margin-bottom: 0.5rem;
+    transition: transform 0.2s ease-in-out;
+}
+
+.client-logo:hover {
+    transform: scale(1.05);
 }
 
 .testimonials {
@@ -154,9 +173,25 @@ footer {
     nav {
         flex-direction: column;
         gap: 1rem;
+        position: relative;
+    }
+    .menu-toggle {
+        display: block;
+    }
+    .nav-links {
+        display: none;
+        flex-direction: column;
+        gap: 1rem;
+        background: #1a2940;
+        padding: 1rem;
+        border-radius: 8px;
+        width: 100%;
+    }
+    nav.nav-open .nav-links {
+        display: flex;
     }
     .clients-logos {
         flex-direction: column;
         gap: 1rem;
     }
-} 
+}


### PR DESCRIPTION
## Summary
- add SEO meta description and inline favicon
- introduce a hamburger menu for small screens
- wrap content in `<main>` and add script for toggling nav
- provide accessibility labels on client SVG logos
- animate service and client items on hover
- add responsive nav styles

## Testing
- `npm test` *(fails: could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_6866a38354d0832bbe77c646707e4c05